### PR TITLE
adds course to breadcrumb if block is inside a course

### DIFF
--- a/pages/notifications.php
+++ b/pages/notifications.php
@@ -64,11 +64,11 @@ $context = context_system::instance();
 $allnotifs = has_capability('block/advnotifications:managenotifications', $context);
 $ownnotifs = false;
 
+$bcontext = context_block::instance($blockinstance);
 if (!$allnotifs) {
     if (empty($blockinstance) || !isset($blockinstance) || $blockinstance === -1) {
         throw new moodle_exception('advnotifications_err_nocapability', 'block_advnotifications');
     }
-    $bcontext = context_block::instance($blockinstance);
     $ownnotifs = has_capability('block/advnotifications:manageownnotifications', $bcontext);
 }
 
@@ -94,6 +94,10 @@ if (!$table->is_downloading()) {
     $PAGE->set_heading(get_string('advnotifications_table_heading', 'block_advnotifications'));
     $PAGE->requires->jquery();
     $PAGE->requires->js_call_amd('block_advnotifications/custom', 'initialise');
+    if ($ccontext = $bcontext->get_course_context(false)) {
+        $course = $DB->get_field('course', 'fullname', ['id' => $ccontext->instanceid]);
+        $PAGE->navbar->add(format_string($course), new moodle_url('/course/view.php', ['id' => $ccontext->instanceid]));
+    }
     $PAGE->navbar->add(get_string('blocks'));
     $PAGE->navbar->add(get_string('pluginname', 'block_advnotifications'));
     $PAGE->navbar->add(get_string('advnotifications_table_title_short', 'block_advnotifications'));

--- a/pages/notifications.php
+++ b/pages/notifications.php
@@ -40,7 +40,6 @@ $download = optional_param('download', '', PARAM_ALPHA);
 // Determines whether notification is global or instance-based.
 $blockinstance = optional_param('blockid', '', PARAM_INT);
 
-
 // Used for navigation links to keep track of blockid (if any).
 $param = '';
 $xparam = '';
@@ -55,6 +54,7 @@ if (isset($blockinstance) && $blockinstance !== '') {
     $param = '?blockid=' . $blockinstance;
     $xparam = '&blockid=' . $blockinstance;
     $params['blockid'] = $blockinstance;
+    $bcontext = context_block::instance($blockinstance);
 }
 
 // Force the user to login/create an account to access this page.
@@ -64,7 +64,6 @@ $context = context_system::instance();
 $allnotifs = has_capability('block/advnotifications:managenotifications', $context);
 $ownnotifs = false;
 
-$bcontext = context_block::instance($blockinstance);
 if (!$allnotifs) {
     if (empty($blockinstance) || !isset($blockinstance) || $blockinstance === -1) {
         throw new moodle_exception('advnotifications_err_nocapability', 'block_advnotifications');
@@ -94,7 +93,7 @@ if (!$table->is_downloading()) {
     $PAGE->set_heading(get_string('advnotifications_table_heading', 'block_advnotifications'));
     $PAGE->requires->jquery();
     $PAGE->requires->js_call_amd('block_advnotifications/custom', 'initialise');
-    if ($ccontext = $bcontext->get_course_context(false)) {
+    if (isset($bcontext) && $ccontext = $bcontext->get_course_context(false)) {
         $course = $DB->get_field('course', 'fullname', ['id' => $ccontext->instanceid]);
         $PAGE->navbar->add(format_string($course), new moodle_url('/course/view.php', ['id' => $ccontext->instanceid]));
     }


### PR DESCRIPTION
Hi,
Hope you like this little improvement.
It helps admin keeps context of the course in case he/she is accessing the block inside a course.

I would also consider add the the corresponding course to each notification on the table. What do you think about it?

Also, I'm planning to make some other improvements to this plugin like the ability to send Moodle notifications (that will appear on the bell icon and will be sent optionally via email or push notifications to the app) on the start date of a notification.

Best,
Daniel