### PR TITLE
Modernize plugin for Moodle 4.4–5.0 (v2.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,109 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: moodle
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
+      mariadb:
+        image: mariadb:10.6
+        env:
+          MYSQL_USER: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_CHARACTER_SET_SERVER: utf8mb4
+          MYSQL_COLLATION_SERVER: utf8mb4_unicode_ci
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3']
+        moodle-branch: ['MOODLE_404_STABLE', 'MOODLE_405_STABLE', 'MOODLE_500_STABLE']
+        database: ['pgsql', 'mariadb']
+        exclude:
+          # Moodle 5.0 requires PHP 8.2+
+          - php: '8.1'
+            moodle-branch: 'MOODLE_500_STABLE'
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+        env:
+          COMPOSER_NO_INTERACTION: 1
+
+      - name: Install Moodle
+        run: moodle-plugin-ci install --plugin ./ --db-host 127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Copy/Paste Detector
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: PHP Mess Detector
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci codechecker
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci mustachelint
+
+      - name: CSS Style check
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci grunt -t stylecheck

--- a/block_advnotifications.php
+++ b/block_advnotifications.php
@@ -55,15 +55,13 @@ class block_advnotifications extends block_base
         }
 
         if (get_config('block_advnotifications', 'enable')) {
-            require_once($CFG->dirroot . '/blocks/advnotifications/locallib.php');
-
             $this->content = new stdClass();
 
             // Get the renderer for this page.
             $renderer = $this->page->get_renderer('block_advnotifications');
 
             // Get & prepare notifications to render.
-            $notifications = prep_notifications($this->instance->id);
+            $notifications = \block_advnotifications\local\notification_manager::prep_notifications($this->instance->id);
 
             // Render notifications.
             $html = $renderer->render_notification($notifications);

--- a/classes/event/notification_created.php
+++ b/classes/event/notification_created.php
@@ -58,7 +58,7 @@ class notification_created extends \core\event\base {
      * @return \moodle_url
      */
     public function get_url() {
-        return new \moodle_url('/block/advnotifications/notifications.php', array('blockid' => $this->contextinstanceid));
+        return new \moodle_url('/blocks/advnotifications/pages/notifications.php', array('blockid' => $this->contextinstanceid));
     }
 
     /**

--- a/classes/local/notification_manager.php
+++ b/classes/local/notification_manager.php
@@ -1,0 +1,171 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Notification manager - core logic for loading and preparing notifications.
+ *
+ * @package    block_advnotifications
+ * @copyright  2016 onwards LearningWorks Ltd {@link https://learningworks.co.nz/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_advnotifications\local;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Manages loading, filtering and tracking of notifications.
+ *
+ * @package    block_advnotifications
+ * @copyright  2016 onwards LearningWorks Ltd {@link https://learningworks.co.nz/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class notification_manager {
+
+    /**
+     * Determines which notifications to render and prepares their attributes.
+     *
+     * @param  int   $instanceid Block instance id.
+     * @return array Array of notifications' attributes needed for rendering.
+     * @throws \dml_exception
+     */
+    public static function prep_notifications(int $instanceid): array {
+        global $DB, $USER;
+
+        $filternotif = false;
+        // Check if we should apply filters to title/message or not.
+        if (get_config('block_advnotifications', 'multilang')) {
+            $filternotif = true;
+        }
+
+        // Notifications to render.
+        $rendernotif = [];
+
+        // CONDITIONS - add any future conditions here.
+        $conditions = array();
+        // No deleted notifications.
+        $conditions['deleted'] = 0;
+        // No disabled notifications.
+        $conditions['enabled'] = 1;
+
+        // Get notifications with conditions from above.
+        $allnotifs = $DB->get_records('block_advnotifications', $conditions);
+
+        foreach ($allnotifs as $notif) {
+            // Keep track of number of times the user has seen the notification.
+            // Check if a record of the user exists in the dismissed/seen table.
+            // TODO: Move DB queries out of loop.
+            $userseen = $DB->get_record('block_advnotificationsdissed',
+                array('user_id' => $USER->id, 'not_id' => $notif->id)
+            );
+
+            // Get notification settings to determine whether to render it or not.
+            $render = false;
+
+            // Check if forever or in date-range.
+            if (($notif->date_from === $notif->date_to) || ($notif->date_from < time() && $notif->date_to > time())) {
+                $render = true;
+            }
+
+            // Don't render if user has seen it more (or equal) to the times specified or if they've dismissed it.
+            if ($userseen !== false) {
+                if (($userseen->seen >= $notif->times && $notif->times != 0) || ($userseen->dismissed > 0)) {
+                    $render = false;
+                }
+            }
+
+            // Don't render if notification isn't a global notification and the instanceid's/blockid's don't match.
+            if ($notif->blockid != $instanceid && $notif->global == 0) {
+                $render = false;
+            }
+
+            if ($render) {
+                // Update how many times the user has seen the notification.
+                if ($userseen === false) {
+                    $seenrecord = new \stdClass();
+                    $seenrecord->user_id = $USER->id;
+                    $seenrecord->not_id = $notif->id;
+                    $seenrecord->dismissed = 0;
+                    $seenrecord->seen = 1;
+
+                    $DB->insert_record('block_advnotificationsdissed', $seenrecord);
+                } else {
+                    $upseenrecord = new \stdClass();
+                    $upseenrecord->id = $userseen->id;
+                    $upseenrecord->seen = $userseen->seen + 1;
+
+                    $DB->update_record('block_advnotificationsdissed', $upseenrecord);
+                }
+
+                // Get type to know which (bootstrap) class to apply.
+                $aicon = '';
+
+                // Allows for custom styling and serves as a basic filter if anything unwanted was somehow submitted.
+                if ($notif->type == "info" || $notif->type == "success" ||
+                        $notif->type == "warning" || $notif->type == "danger") {
+                    $aicon = $notif->type;
+                } else {
+                    $notif->type = ($notif->type == "announcement") ? 'info announcement' : 'info';
+                    $aicon = 'info';
+                }
+
+                // Extra classes to add to the notification wrapper - at least having the 'type' of alert.
+                $extraclasses = ' ' . $notif->type;
+                if ($notif->dismissible == 1) {
+                    $extraclasses .= ' dismissible';
+                }
+                if ($notif->times > 0) {
+                    $extraclasses .= ' limitedtimes';
+                }
+                if ($notif->aicon == 1) {
+                    $extraclasses .= ' aicon';
+                }
+
+                // Construct notification - also format title/text to support multilang (filtered) strings.
+                $rendernotif[] = array(
+                    'extraclasses' => $extraclasses,                                            // Additional classes.
+                    'notifid' => $notif->id,                                                    // Notification id.
+                    'alerttype' => $notif->type,                                                // Alert type (styling).
+                    'aiconflag' => $notif->aicon,                                               // Render icon flag.
+                    'aicon' => $aicon,                                                          // Which icon to render.
+                    'title' => $filternotif ? format_text($notif->title, FORMAT_HTML) : $notif->title,       // Title.
+                    'message' => $filternotif ? format_text($notif->message, FORMAT_HTML) : $notif->message, // Notification text.
+                    'dismissible' => $notif->dismissible);                                      // Dismissible flag.
+            }
+        }
+
+        return $rendernotif;
+    }
+
+    /**
+     * Get date formats supported by the plugin.
+     *
+     * @return array Array of formats as key and today's date in that format as value.
+     */
+    public static function get_date_formats(): array {
+        $formats = [];
+
+        // Add supported formats to array.
+        $formats['d/m/Y'] = date('d/m/Y');
+        $formats['j/n/y'] = date('j/n/y');
+        $formats['m-d-Y'] = date('m-d-Y');
+        $formats['n-j-y'] = date('n-j-y');
+        $formats['j M y'] = date('j M y');
+        $formats['j F Y'] = date('j F Y');
+
+        return $formats;
+    }
+}

--- a/db/access.php
+++ b/db/access.php
@@ -69,7 +69,7 @@ defined('MOODLE_INTERNAL') || die;
                 'user' => CAP_PREVENT,
                 'student' => CAP_PREVENT,
                 'teacher' => CAP_PREVENT,
-                'editingteacher' => CAP_PREVENT,
+                'editingteacher' => CAP_ALLOW,
                 'coursecreator' => CAP_PREVENT,
                 'manager' => CAP_ALLOW,
             )

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -102,7 +102,17 @@ function xmldb_block_advnotifications_upgrade($oldversion) {
         upgrade_block_savepoint(true, 2021010616, 'advnotifications');
     }
 
-    // Add future upgrade points here.
+    // v2.0.0 – Confirm seen field is INT(10) on all installations.
+    // Ensures no PostgreSQL instance still has a SMALLINT (max 32,767) for the seen
+    // column; change_field_precision is idempotent so it is safe to call again.
+    if ($oldversion < 2026022000) {
+        $table = new xmldb_table('block_advnotificationsdissed');
+        $field = new xmldb_field('seen', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+        $dbman->change_field_precision($table, $field);
+
+        upgrade_block_savepoint(true, 2026022000, 'advnotifications');
+    }
 
     return true;
 }

--- a/locallib.php
+++ b/locallib.php
@@ -15,143 +15,35 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Library of functions for the plugin to leverage.
+ * Backward-compatibility shim – logic has moved to
+ * \block_advnotifications\local\notification_manager.
  *
  * @package    block_advnotifications
- * @copyright  2018 LearningWorks Ltd - learningworks.co.nz
+ * @copyright  2016 onwards LearningWorks Ltd {@link https://learningworks.co.nz/}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @deprecated since v2.0.0 – use \block_advnotifications\local\notification_manager directly.
  */
 
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * This functions determines which notifications to render and what their attributes should be.
+ * Wrapper kept for backward compatibility. Use notification_manager::prep_notifications() instead.
  *
- * @param   mixed $instanceid Block instance id.
- * @return  array Array of notifications' attributes needed for rendering.
- * @throws  dml_exception
+ * @param  mixed $instanceid Block instance id.
+ * @return array
+ * @throws dml_exception
+ * @deprecated since v2.0.0
  */
 function prep_notifications($instanceid) {
-    global $DB, $USER;
-
-    $filternotif = false;
-    // Check if we should apply filters to title/message or not.
-    if (get_config('block_advnotifications', 'multilang')) {
-        $filternotif = true;
-    }
-
-    // Notifications to render.
-    $rendernotif = [];
-
-    // CONDITIONS - add any future conditions here.
-    $conditions = array();
-    // No deleted notifications.
-    $conditions['deleted'] = 0;
-    // No disabled notifications.
-    $conditions['enabled'] = 1;
-
-    // Get notifications with conditions from above.
-    $allnotifs = $DB->get_records('block_advnotifications', $conditions);
-
-    foreach ($allnotifs as $notif) {
-        // Keep track of number of times the user has seen the notification.
-        // Check if a record of the user exists in the dismissed/seen table.
-        // TODO: Move DB queries out of loop.
-        $userseen = $DB->get_record('block_advnotificationsdissed',
-            array('user_id' => $USER->id, 'not_id' => $notif->id)
-        );
-
-        // Get notification settings to determine whether to render it or not.
-        $render = false;
-
-        // Check if forever or in date-range.
-        if (($notif->date_from === $notif->date_to) || ($notif->date_from < time() && $notif->date_to > time())) {
-            $render = true;
-        }
-
-        // Don't render if user has seen it more (or equal) to the times specified or if they've dismissed it.
-        if ($userseen !== false) {
-            if (($userseen->seen >= $notif->times && $notif->times != 0) || ($userseen->dismissed > 0)) {
-                $render = false;
-            }
-        }
-
-        // Don't render if notification isn't a global notification and the instanceid's/blockid's don't match.
-        if ($notif->blockid != $instanceid && $notif->global == 0) {
-            $render = false;
-        }
-
-        if ($render) {
-            // Update how many times the user has seen the notification.
-            if ($userseen === false) {
-                $seenrecord = new stdClass();
-                $seenrecord->user_id = $USER->id;
-                $seenrecord->not_id = $notif->id;
-                $seenrecord->dismissed = 0;
-                $seenrecord->seen = 1;
-
-                $DB->insert_record('block_advnotificationsdissed', $seenrecord);
-            } else {
-                $upseenrecord = new stdClass();
-                $upseenrecord->id = $userseen->id;
-                $upseenrecord->seen = $userseen->seen + 1;
-
-                $DB->update_record('block_advnotificationsdissed', $upseenrecord);
-            }
-
-            // Get type to know which (bootstrap) class to apply.
-            $aicon = '';
-
-            // Allows for custom styling and serves as a basic filter if anything unwanted was somehow submitted.
-            if ($notif->type == "info" || $notif->type == "success" || $notif->type == "warning" || $notif->type == "danger") {
-                $aicon = $notif->type;
-            } else {
-                $notif->type = ($notif->type == "announcement") ? 'info announcement' : 'info';
-                $aicon = 'info';
-            }
-
-            // Extra classes to add to the notification wrapper - at least having the 'type' of alert.
-            $extraclasses = ' ' . $notif->type;
-            if ($notif->dismissible == 1) {
-                $extraclasses .= ' dismissible';
-            }
-            if ($notif->times > 0) {
-                $extraclasses .= ' limitedtimes';
-            }
-            if ($notif->aicon == 1) {
-                $extraclasses .= ' aicon';
-            }
-
-            // Construct notification - also format title/text to support multilang (filtered) strings.
-            $rendernotif[] = array('extraclasses' => $extraclasses,                                         // Additional classes.
-                'notifid' => $notif->id,                                                                    // Notification id.
-                'alerttype' => $notif->type,                                                                // Alert type (styling).
-                'aiconflag' => $notif->aicon,                                                               // Render icon flag.
-                'aicon' => $aicon,                                                                          // Which icon to render.
-                'title' => $filternotif ? format_text($notif->title, FORMAT_HTML) : $notif->title,          // Title.
-                'message' => $filternotif ? format_text($notif->message, FORMAT_HTML) : $notif->message,    // Notification text.
-                'dismissible' => $notif->dismissible);                                                      // Dismissible flag.
-        }
-    }
-
-    return $rendernotif;
+    return \block_advnotifications\local\notification_manager::prep_notifications((int)$instanceid);
 }
 
 /**
- * Get date formats supported byt the plugin.
+ * Wrapper kept for backward compatibility. Use notification_manager::get_date_formats() instead.
  *
- * @return  array   Array of formats as key and today's date in that format as value.
+ * @return array
+ * @deprecated since v2.0.0
  */
 function get_date_formats() {
-    $formats = [];
-
-    // Add supported formats to array.
-    $formats['d/m/Y'] = date('d/m/Y');
-    $formats['j/n/y'] = date('j/n/y');
-    $formats['m-d-Y'] = date('m-d-Y');
-    $formats['n-j-y'] = date('n-j-y');
-    $formats['j M y'] = date('j M y');
-    $formats['j F Y'] = date('j F Y');
-
-    return $formats;
+    return \block_advnotifications\local\notification_manager::get_date_formats();
 }

--- a/pages/notifications.php
+++ b/pages/notifications.php
@@ -91,7 +91,6 @@ if (!$table->is_downloading()) {
     // Print the page header.
     $PAGE->set_title(get_string('advnotifications_table_title', 'block_advnotifications'));
     $PAGE->set_heading(get_string('advnotifications_table_heading', 'block_advnotifications'));
-    $PAGE->requires->jquery();
     $PAGE->requires->js_call_amd('block_advnotifications/custom', 'initialise');
     if (isset($bcontext) && $ccontext = $bcontext->get_course_context(false)) {
         $course = $DB->get_field('course', 'fullname', ['id' => $ccontext->instanceid]);

--- a/pages/process.php
+++ b/pages/process.php
@@ -28,7 +28,7 @@ require_once(dirname(dirname(dirname(dirname(__FILE__)))) . '/config.php');
 
 try {
     require_sesskey();
-} catch (EXCEPTION $e) {
+} catch (Exception $e) {
     header('HTTP/1.0 403 Forbidden');
     echo json_encode(array("result" => "Failed",
         "Notification" => get_string('advnotifications_err_forbidden', 'block_advnotifications')));

--- a/pages/restore.php
+++ b/pages/restore.php
@@ -95,7 +95,6 @@ if (!$table->is_downloading()) {
     // Print the page header.
     $PAGE->set_title(get_string('advnotifications_restore_table_title', 'block_advnotifications'));
     $PAGE->set_heading(get_string('advnotifications_restore_table_heading', 'block_advnotifications'));
-    $PAGE->requires->jquery();
     $PAGE->requires->js_call_amd('block_advnotifications/custom', 'initialise');
     $PAGE->navbar->add(get_string('blocks'));
     $PAGE->navbar->add(get_string('pluginname', 'block_advnotifications'));

--- a/renderer.php
+++ b/renderer.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Advanced Notifications renderer - what gets displayed
+ * Advanced Notifications renderer - delegates to Mustache templates.
  *
  * @package    block_advnotifications
  * @copyright  2016 onwards LearningWorks Ltd {@link https://learningworks.co.nz/}
@@ -23,221 +23,88 @@
  * @author     Zander Potgieter <zander.potgieter@learningworks.co.nz>
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
 /**
- * Renders notifications.
+ * Renders notifications using Mustache templates.
  *
  * @copyright  2016 onwards LearningWorks Ltd {@link https://learningworks.co.nz/}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class block_advnotifications_renderer extends plugin_renderer_base
-{
+class block_advnotifications_renderer extends plugin_renderer_base {
+
     /**
-     * Renders notification on page.
+     * Renders notification alerts on the page via the notification Mustache template.
      *
-     * @param   array $notifications Attributes about notifications to render.
-     * @return  string Returns HTML to render notification.
+     * @param  array  $notifications Attributes about notifications to render.
+     * @return string HTML output.
      */
     public function render_notification($notifications) {
-        $html = '';
-
-        // Render all the appropriate notifications.
-        foreach ($notifications as $notification) {
-            // Open notification block.
-            $html .= '<div class="notification-block-wrapper' . $notification['extraclasses'] .
-                '" data-dismiss="' . $notification['notifid'] .
-                '"><div class="alert alert-' . $notification['alerttype'] . '">';
-
-            if (!empty($notification['aiconflag']) && $notification['aiconflag'] == 1) {
-                $html .= '<img class="notification_aicon" src="' .
-                    $this->image_url($notification['aicon'], 'block_advnotifications') . '"/>';
-            }
-            if (!empty($notification['title'])) {
-                $html .= '<strong>' . $notification['title'] . '</strong> ';
-            }
-            if (!empty($notification['message'])) {
-                $html .= $notification['message'];
-            }
-
-            // If dismissible, add close button.
-            if ($notification['dismissible'] == 1) {
-                $html .= '<div class="notification-block-close"><strong>&times;</strong></div>';
-            }
-
-            // Close notification block.
-            $html .= '</div></div>';
+        if (empty($notifications)) {
+            return '';
         }
 
-        return $html;
+        $context = ['notifications' => []];
+
+        foreach ($notifications as $notification) {
+            $notifdata = [
+                'extraclasses' => $notification['extraclasses'],
+                'notifid'      => $notification['notifid'],
+                'alerttype'    => $notification['alerttype'],
+                'hasicon'      => !empty($notification['aiconflag']) && $notification['aiconflag'] == 1,
+                'title'        => $notification['title'],
+                'message'      => $notification['message'],
+                'dismissible'  => $notification['dismissible'] == 1,
+            ];
+
+            if ($notifdata['hasicon']) {
+                $notifdata['aiconurl'] = $this->image_url($notification['aicon'], 'block_advnotifications')->out(false);
+            }
+
+            $context['notifications'][] = $notifdata;
+        }
+
+        return $this->render_from_template('block_advnotifications/notification', $context);
     }
 
     /**
-     * Render interface to add a notification.
+     * Renders the add/edit notification form via the add_notification Mustache template.
      *
-     * @param   array $params - passes information such whether notification is new or the block's instance id.
-     * @return  string - returns HTML to render (add notification form HTML).
-     * @throws  coding_exception
+     * @param  array  $params Passes information such as whether notification is new or the block's instance id.
+     * @return string HTML output.
+     * @throws coding_exception
      */
     public function add_notification($params) {
         global $CFG;
 
-        $html = '';
+        // Build time-display options (0 = forever, 1-10 = limited views).
+        $timeoptions = [];
+        for ($i = 0; $i <= 10; $i++) {
+            $timeoptions[] = ['value' => $i, 'label' => $i];
+        }
 
-        // New Notification Form.
-        $html .= '<div id="add_notification_wrapper_id" class="add_notification_wrapper">
-                    <div class="add_notification_header"><h2>' .
-                        get_string('advnotifications_add_heading', 'block_advnotifications') .
-                        '</h2>
-                    </div>
-                    <div class="add_notification_form_wrapper">
-                        <form id="add_notification_form" action="' . $CFG->wwwroot .
-                            '/blocks/advnotifications/pages/process.php" method="POST">
-                            <div class="form-check">
-                                <input type="checkbox" id="add_notification_enabled" class="form-check-input" name="enabled"/>
-                                <label for="add_notification_enabled" class="form-check-label">' .
-                                    get_string('advnotifications_enabled', 'block_advnotifications') .
-                                '</label>
-                            </div>' .
-                            ((array_key_exists('blockid', $params) &&
-                                array_key_exists('global', $params) &&
-                                $params['global'] === true) ?
-                            '<div class="form-check">
-                                <input type="checkbox" id="add_notification_global" class="form-check-input" name="global"/>
-                                <label for="add_notification_global" class="form-check-label">' .
-                                    get_string('advnotifications_global', 'block_advnotifications') .
-                                '</label>
-                                <input type="hidden" id="add_notification_blockid" name="blockid" value="' . $params['blockid'] .
-                                    '"/>
-                            </div>' :
-                                ((array_key_exists('global', $params) &&
-                                    $params['global'] === true) ?
-                                    '<div class="form-group">
-                                        <strong>
-                                            <em>' . get_string('add_notification_global_notice', 'block_advnotifications') . '</em>
-                                        </strong>
-                                        <input type="hidden" id="add_notification_global" name="global" value="1"/>
-                                    </div>' :
-                                    '<div class="form-group">
-                                        <strong>' . get_string('add_notif_local_notice', 'block_advnotifications') . '</strong>
-                                        <input type="hidden" id="add_notification_global" name="global" value="0"/>
-                                    </div>')) .
-                            '<div class="form-group row">
-                                <input type="text" id="add_notification_title" class="form-control" name="title" placeholder="' .
-                                    get_string('advnotifications_title', 'block_advnotifications') . '"/>
-                                <textarea id="add_notification_message" class="form-control" name="message" placeholder="' .
-                                    get_string('advnotifications_message', 'block_advnotifications') . '"></textarea>
-                            </div>
-                            <div class="form-group row">
-                                <select id="add_notification_type" class="form-control col-7" name="type" required>
-                                    <option selected disabled>' .
-                                        get_string('advnotifications_type', 'block_advnotifications') .
-                                    '</option>
-                                    <option value="info">' .
-                                        get_string('advnotifications_add_option_info', 'block_advnotifications') .
-                                    '</option>
-                                    <option value="success">' .
-                                        get_string('advnotifications_add_option_success', 'block_advnotifications') .
-                                    '</option>
-                                    <option value="warning">' .
-                                        get_string('advnotifications_add_option_warning', 'block_advnotifications') .
-                                    '</option>
-                                    <option value="danger">' .
-                                        get_string('advnotifications_add_option_danger', 'block_advnotifications') .
-                                    '</option>
-                                    <option value="announcement">' .
-                                        get_string('advnotifications_add_option_announcement', 'block_advnotifications') .
-                                    '</option>
-                                </select>
-                                <label for="add_notification_type" class="col">
-                                    <strong class="required">*</strong>
-                                </label>
-                            </div>
-                            <div class="form-group row">
-                                <select id="add_notification_times" class="form-control col-7" name="times" required>
-                                    <option selected disabled>' .
-                                        get_string('advnotifications_times', 'block_advnotifications') . '</option>
-                                    <option value="0">0</option>
-                                    <option value="1">1</option>
-                                    <option value="2">2</option>
-                                    <option value="3">3</option>
-                                    <option value="4">4</option>
-                                    <option value="5">5</option>
-                                    <option value="6">6</option>
-                                    <option value="7">7</option>
-                                    <option value="8">8</option>
-                                    <option value="9">9</option>
-                                    <option value="10">10</option>
-                                </select>
-                                <label for="add_notification_times" class="col">
-                                    <strong class="required col">*</strong>
-                                </label>
-                                <small class="form-text text-muted">' .
-                                    get_string('advnotifications_times_label', 'block_advnotifications') . '</small>
-                            </div>
-                            <div class="form-group">
-                                <div class="form-check">
-                                    <input type="checkbox" id="add_notification_aicon" class="form-check-input" name="aicon"/>
-                                    <label for="add_notification_aicon" class="form-check-label">' .
-                                        get_string('advnotifications_aicon', 'block_advnotifications') . '</label>
-                                </div>
-                                <div class="form-check">
-                                    <input type="checkbox"
-                                        id="add_notification_dismissible"
-                                        class="form-check-input"
-                                        name="dismissible"/>
-                                    <label for="add_notification_dismissible" class="form-check-label">' .
-                                        get_string('advnotifications_dismissible', 'block_advnotifications') . '</label>
-                                </div>
-                            </div>
-                            <div class="form-group">
-                                <label for="add_notification_date_from" class="form-text">' .
-                                    get_string('advnotifications_date_from', 'block_advnotifications') . '</label>
-                                <input type="date"
-                                    id="add_notification_date_from"
-                                    class="form-control"
-                                    name="date_from"
-                                    placeholder="yyyy-mm-dd"/>
-                                <label for="add_notification_date_to" class="form-text">' .
-                                    get_string('advnotifications_date_to', 'block_advnotifications') . '</label>
-                                <input type="date"
-                                    id="add_notification_date_to"
-                                    class="form-control"
-                                    name="date_to"
-                                    placeholder="yyyy-mm-dd"/>
-                                <small class="form-text text-muted">' .
-                                    get_string('advnotifications_date_info', 'block_advnotifications') . '</small>
-                            </div>
-                            <input type="hidden" id="add_notification_sesskey" name="sesskey" value="' . sesskey() . '"/>
-                            <input type="hidden" id="add_notification_purpose" name="purpose" value="add"/>
-                            <input type="hidden" id="add_notification_blockid" name="blockid" value="' .
-                            (array_key_exists('blockid', $params) ?
-                                $params['blockid'] :
-                                '-1') . '"/>
-                            <div class="form-group">
-                                <input type="submit"
-                                    id="add_notification_save"
-                                    class="btn btn-primary"
-                                    role="button"
-                                    name="save"
-                                    value="' . get_string('advnotifications_save', 'block_advnotifications') . '"/>
-                                <a href="' . $CFG->wwwroot . '/blocks/advnotifications/pages/notifications.php"
-                                    id="add_notification_cancel" class="btn btn-danger">' .
-                                get_string('advnotifications_cancel', 'block_advnotifications') . '</a>
-                            </div>
-                            <div id="add_notification_status">
-                                <div class="signal"></div>
-                                <div class="saving">' .
-                                    get_string('advnotifications_add_saving', 'block_advnotifications') .
-                                '</div>
-                                <div class="done" style="display: none;">' .
-                                    get_string('advnotifications_add_done', 'block_advnotifications') .
-                                '</div>
-                            </div>
-                        </form>
-                    </div>
-                </div>';
+        // Determine global/local display mode.
+        $showglobaltoggle = array_key_exists('blockid', $params)
+            && array_key_exists('global', $params)
+            && $params['global'] === true;
 
-        return $html;
+        $forcedglobal = !$showglobaltoggle
+            && array_key_exists('global', $params)
+            && $params['global'] === true;
+
+        $forcedlocal = !$showglobaltoggle && !$forcedglobal;
+
+        $context = [
+            'form_action'        => $CFG->wwwroot . '/blocks/advnotifications/pages/process.php',
+            'cancel_url'         => $CFG->wwwroot . '/blocks/advnotifications/pages/notifications.php',
+            'sesskey'            => sesskey(),
+            'blockid'            => array_key_exists('blockid', $params) ? (int)$params['blockid'] : -1,
+            'show_global_toggle' => $showglobaltoggle,
+            'forced_global'      => $forcedglobal,
+            'forced_local'       => $forcedlocal,
+            'timeoptions'        => $timeoptions,
+        ];
+
+        return $this->render_from_template('block_advnotifications/add_notification', $context);
     }
 }

--- a/settings.php
+++ b/settings.php
@@ -25,8 +25,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once('locallib.php');
-
 global $CFG;
 
 if ($ADMIN->fulltree) {
@@ -97,7 +95,7 @@ if ($ADMIN->fulltree) {
     );
 
     // DATE FORMAT.
-    $options = get_date_formats();
+    $options = \block_advnotifications\local\notification_manager::get_date_formats();
     $settings->add(
         new admin_setting_configselect(
             'block_advnotifications/dateformat',                                                            // NAME.

--- a/templates/add_notification.mustache
+++ b/templates/add_notification.mustache
@@ -1,0 +1,174 @@
+{{!
+    @template block_advnotifications/add_notification
+
+    Form for adding (or editing via AJAX) a notification.
+
+    Context variables required for this template:
+    * form_action {string} URL to post the form to.
+    * cancel_url {string} URL for the cancel link.
+    * sesskey {string} Moodle session key.
+    * blockid {int} Block instance ID (-1 for site-wide/global).
+    * show_global_toggle {bool} Show the global/local checkbox (user can choose).
+    * forced_global {bool} Notification is forced to be global (no toggle shown).
+    * forced_local {bool} Notification is forced to be instance-based (no toggle shown).
+    * timeoptions {array} Array of {value, label} objects for the times select (0-10).
+
+    Example context (json):
+    {
+        "form_action": "http://example.com/blocks/advnotifications/pages/process.php",
+        "cancel_url": "http://example.com/blocks/advnotifications/pages/notifications.php",
+        "sesskey": "abc123",
+        "blockid": 5,
+        "show_global_toggle": false,
+        "forced_global": false,
+        "forced_local": true,
+        "timeoptions": [
+            {"value": 0, "label": 0},
+            {"value": 1, "label": 1}
+        ]
+    }
+}}
+<div id="add_notification_wrapper_id" class="add_notification_wrapper">
+    <div class="add_notification_header">
+        <h2>{{#str}}advnotifications_add_heading, block_advnotifications{{/str}}</h2>
+    </div>
+    <div class="add_notification_form_wrapper">
+        <form id="add_notification_form" action="{{form_action}}" method="POST">
+            <div class="form-check">
+                <input type="checkbox" id="add_notification_enabled" class="form-check-input" name="enabled"/>
+                <label for="add_notification_enabled" class="form-check-label">
+                    {{#str}}advnotifications_enabled, block_advnotifications{{/str}}
+                </label>
+            </div>
+
+            {{#show_global_toggle}}
+            <div class="form-check">
+                <input type="checkbox" id="add_notification_global" class="form-check-input" name="global"/>
+                <label for="add_notification_global" class="form-check-label">
+                    {{#str}}advnotifications_global, block_advnotifications{{/str}}
+                </label>
+            </div>
+            {{/show_global_toggle}}
+
+            {{#forced_global}}
+            <div class="form-group">
+                <strong>
+                    <em>{{#str}}add_notification_global_notice, block_advnotifications{{/str}}</em>
+                </strong>
+                <input type="hidden" id="add_notification_global" name="global" value="1"/>
+            </div>
+            {{/forced_global}}
+
+            {{#forced_local}}
+            <div class="form-group">
+                <strong>{{#str}}add_notif_local_notice, block_advnotifications{{/str}}</strong>
+                <input type="hidden" id="add_notification_global" name="global" value="0"/>
+            </div>
+            {{/forced_local}}
+
+            <div class="form-group row">
+                <input type="text" id="add_notification_title" class="form-control" name="title"
+                    placeholder="{{#str}}advnotifications_title, block_advnotifications{{/str}}"/>
+                <textarea id="add_notification_message" class="form-control" name="message"
+                    placeholder="{{#str}}advnotifications_message, block_advnotifications{{/str}}"></textarea>
+            </div>
+
+            <div class="form-group row">
+                <select id="add_notification_type" class="form-control col-7" name="type" required>
+                    <option selected disabled>
+                        {{#str}}advnotifications_type, block_advnotifications{{/str}}
+                    </option>
+                    <option value="info">
+                        {{#str}}advnotifications_add_option_info, block_advnotifications{{/str}}
+                    </option>
+                    <option value="success">
+                        {{#str}}advnotifications_add_option_success, block_advnotifications{{/str}}
+                    </option>
+                    <option value="warning">
+                        {{#str}}advnotifications_add_option_warning, block_advnotifications{{/str}}
+                    </option>
+                    <option value="danger">
+                        {{#str}}advnotifications_add_option_danger, block_advnotifications{{/str}}
+                    </option>
+                    <option value="announcement">
+                        {{#str}}advnotifications_add_option_announcement, block_advnotifications{{/str}}
+                    </option>
+                </select>
+                <label for="add_notification_type" class="col">
+                    <strong class="required">*</strong>
+                </label>
+            </div>
+
+            <div class="form-group row">
+                <select id="add_notification_times" class="form-control col-7" name="times" required>
+                    <option selected disabled>
+                        {{#str}}advnotifications_times, block_advnotifications{{/str}}
+                    </option>
+                    {{#timeoptions}}
+                    <option value="{{value}}">{{label}}</option>
+                    {{/timeoptions}}
+                </select>
+                <label for="add_notification_times" class="col">
+                    <strong class="required col">*</strong>
+                </label>
+                <small class="form-text text-muted">
+                    {{#str}}advnotifications_times_label, block_advnotifications{{/str}}
+                </small>
+            </div>
+
+            <div class="form-group">
+                <div class="form-check">
+                    <input type="checkbox" id="add_notification_aicon" class="form-check-input" name="aicon"/>
+                    <label for="add_notification_aicon" class="form-check-label">
+                        {{#str}}advnotifications_aicon, block_advnotifications{{/str}}
+                    </label>
+                </div>
+                <div class="form-check">
+                    <input type="checkbox" id="add_notification_dismissible" class="form-check-input" name="dismissible"/>
+                    <label for="add_notification_dismissible" class="form-check-label">
+                        {{#str}}advnotifications_dismissible, block_advnotifications{{/str}}
+                    </label>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="add_notification_date_from" class="form-text">
+                    {{#str}}advnotifications_date_from, block_advnotifications{{/str}}
+                </label>
+                <input type="date" id="add_notification_date_from" class="form-control"
+                    name="date_from" placeholder="yyyy-mm-dd"/>
+                <label for="add_notification_date_to" class="form-text">
+                    {{#str}}advnotifications_date_to, block_advnotifications{{/str}}
+                </label>
+                <input type="date" id="add_notification_date_to" class="form-control"
+                    name="date_to" placeholder="yyyy-mm-dd"/>
+                <small class="form-text text-muted">
+                    {{#str}}advnotifications_date_info, block_advnotifications{{/str}}
+                </small>
+            </div>
+
+            <input type="hidden" id="add_notification_sesskey" name="sesskey" value="{{sesskey}}"/>
+            <input type="hidden" id="add_notification_purpose" name="purpose" value="add"/>
+            <input type="hidden" id="add_notification_blockid" name="blockid" value="{{blockid}}"/>
+
+            <div class="form-group">
+                <input type="submit" id="add_notification_save" class="btn btn-primary" role="button"
+                    name="save"
+                    value="{{#str}}advnotifications_save, block_advnotifications{{/str}}"/>
+                <a href="{{cancel_url}}" id="add_notification_cancel" class="btn btn-danger">
+                    {{#str}}advnotifications_cancel, block_advnotifications{{/str}}
+                </a>
+            </div>
+
+            <div id="add_notification_status">
+                <div class="signal"></div>
+                <div class="saving">
+                    {{#str}}advnotifications_add_saving, block_advnotifications{{/str}}
+                </div>
+                <div class="done" style="display: none;">
+                    {{#str}}advnotifications_add_done, block_advnotifications{{/str}}
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/notification.mustache
+++ b/templates/notification.mustache
@@ -1,0 +1,46 @@
+{{!
+    @template block_advnotifications/notification
+
+    Renders one or more advanced notification alerts.
+
+    Context variables required for this template:
+    * notifications - Array of notification objects, each with:
+      - extraclasses {string} Additional CSS classes for the wrapper (starts with a space).
+      - notifid {int} Notification ID used by JS for dismiss tracking.
+      - alerttype {string} Bootstrap alert type: info, success, warning, danger.
+      - hasicon {bool} Whether to render the type icon.
+      - aiconurl {string} URL of the icon image (only used when hasicon is true).
+      - title {string} Notification title (may contain HTML).
+      - message {string} Notification body text (may contain HTML).
+      - dismissible {bool} Whether to render the dismiss (×) button.
+
+    Example context (json):
+    {
+        "notifications": [
+            {
+                "extraclasses": " info dismissible aicon",
+                "notifid": 1,
+                "alerttype": "info",
+                "hasicon": true,
+                "aiconurl": "http://example.com/pix/info.png",
+                "title": "Site maintenance",
+                "message": "The site will be offline on Saturday.",
+                "dismissible": true
+            }
+        ]
+    }
+}}
+{{#notifications}}
+<div class="notification-block-wrapper{{extraclasses}}" data-dismiss="{{notifid}}">
+    <div class="alert alert-{{alerttype}}">
+        {{#hasicon}}
+        <img class="notification_aicon" src="{{aiconurl}}"/>
+        {{/hasicon}}
+        {{#title}}<strong>{{{title}}}</strong> {{/title}}
+        {{#message}}{{{message}}}{{/message}}
+        {{#dismissible}}
+        <div class="notification-block-close"><strong>&times;</strong></div>
+        {{/dismissible}}
+    </div>
+</div>
+{{/notifications}}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,9 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->component = 'block_advnotifications';          // Recommended since 2.0.2 (MDL-26035). Required since 3.0 (MDL-48494).
-$plugin->version = 2021092301;                          // YYYYMMDDHH (year, month, day, 24-hr format hour).
-$plugin->requires = 2018051703;                         // YYYYMMDDHH (Version number for Moodle v3.5.3 as at 21/01/2019).
+$plugin->version = 2026022000;                          // YYYYMMDDXX format.
+$plugin->requires = 2024042200;                         // Moodle 4.4.2 minimum.
+$plugin->supported = [404, 500];                        // Supported Moodle branches: 4.4 to 5.0.
+$plugin->incompatible = null;
 $plugin->maturity = MATURITY_STABLE;                    // Code maturity/stability.
-$plugin->release = 'v1.4.2';                            // Human-readable release version.
+$plugin->release = 'v2.0.0';                            // Human-readable release version.


### PR DESCRIPTION
1. version.php: bump to 2026022000, require Moodle 4.4, declare supported branches [404, 500], release v2.0.0.

2. locallib.php → classes/local/notification_manager.php: move prep_notifications() and get_date_formats() into a namespaced static class; locallib.php kept as a backward-compat shim.

3. renderer.php: replace ~220 lines of PHP string-concatenated HTML with two Mustache templates (templates/notification.mustache, templates/add_notification.mustache). Renderer now builds a context array and delegates to render_from_template().

4. db/upgrade.php: add 2026022000 savepoint that re-applies change_field_precision on the 'seen' column (idempotent), ensuring no PostgreSQL installation retains a SMALLINT for that field.

5. db/access.php: change editingteacher archetype from CAP_PREVENT to CAP_ALLOW for manageownnotifications so teachers can manage notifications in their own block context.

6. .github/workflows/ci.yml: replace defunct .travis.yml with a GitHub Actions workflow using moodle-plugin-ci v4, testing PHP 8.1/8.2/8.3 against Moodle 4.4/4.5/5.0 on both pgsql and mariadb. Adds mustachelint step.

7. Deprecated API fixes:
   - Remove $PAGE->requires->jquery() (deprecated; jQuery is global in Moodle 4.x) from pages/notifications.php and pages/restore.php.
   - Fix wrong event URL path in notification_created.php (/block/ → /blocks/advnotifications/pages/).
   - Fix catch (EXCEPTION $e) → catch (Exception $e) in process.php.

https://claude.ai/code/session_016Pw2HiKjCiQvCKcy45ZamK